### PR TITLE
docs: fix forking instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ Steps to run build and package. From root folder -
 2. Decide which extension do you want. Lets say you want "Checklist" extension.
 3. Go to "src" folder and delete all folders except "Checklist" and "Library". "Library" holds a set of common components/utilities that every extension of mine uses, so you need this folder.
 4. In Apps.js file, remove everything except "Checklist"
-5. In tsconfig file, edit "paths" property. Remove all except "Checklist" and "Library". 
-6. In webpack.config.js file, edit "alias". Remove all except "Checklist" and "Library". 
+5. In tsconfig file, edit "paths" property. Remove all except "Checklist", "Library", "VSSUI", and "OfficeFabric". 
+6. In webpack.config.js file, edit "alias". Remove all except "Checklist", "Library", "VSSUI", and "OfficeFabric". 
 
 And you are all set. Run "npm run package" to build and package your extension and "npm start" to start a local dev server
 


### PR DESCRIPTION
Following the forking instructions in readme.md resulted in build errors due to removing VSSUI and OfficeFabric.